### PR TITLE
feat: support online search and related settings

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -13,6 +13,7 @@ import { checkFont } from './utils/fontValidator'
 type ColorChoices = 'default' | 'accentColor' | 'custom'
 type LogoChoiches = 'default' | 'imagePath' | 'imageLink' | 'lucideIcon' | 'none'
 type FontChoiches = 'interfaceFont' | 'textFont' | 'monospaceFont' | 'custom'
+type absentFileChoices = 'createFile' | 'searchOnline'
 
 interface ObjectKeys {
     [key: string]: any
@@ -55,6 +56,8 @@ export interface HomeTabSettings extends ObjectKeys{
     closePreviousSessionTabs: boolean
     omnisearch: boolean
     showOmnisearchExcerpt: boolean
+    searchOnlineUrl: string
+    absentFileBehaviour: absentFileChoices
 }
 
 export const DEFAULT_SETTINGS: HomeTabSettings = {
@@ -88,6 +91,8 @@ export const DEFAULT_SETTINGS: HomeTabSettings = {
     closePreviousSessionTabs: false,
     omnisearch: false,
     showOmnisearchExcerpt: true,
+    searchOnlineUrl: 'https://www.google.com/search?q=',
+    absentFileBehaviour: 'createFile'
 }
 
 
@@ -127,6 +132,16 @@ export class HomeTabSettingTab extends PluginSettingTab{
                     .setValue(this.plugin.settings.closePreviousSessionTabs)
                     .onChange(value => {this.plugin.settings.closePreviousSessionTabs = value; this.plugin.saveSettings()}))
         }
+
+        new Setting(containerEl)
+            .setName('Absent file behaviour')
+            .setDesc('What to do if the file does not exist.')
+            .addDropdown((dropdown) => dropdown
+                .addOption('createFile', 'Create new file')
+                .addOption('searchOnline', 'Search online')
+                .setValue(this.plugin.settings.absentFileBehaviour)
+                .onChange((value: absentFileChoices) => {this.plugin.settings.absentFileBehaviour = value; this.plugin.saveSettings();}))
+            .then((settingEl) => this.addResetButton(settingEl, 'absentFileBehaviour'))
 
 		containerEl.createEl('h2', {text: 'Search settings'});
         if(this.plugin.app.plugins.getPlugin('omnisearch')){
@@ -189,6 +204,17 @@ export class HomeTabSettingTab extends PluginSettingTab{
                 .setDynamicTooltip()
                 .onChange((value) => {this.plugin.settings.searchDelay = value; this.plugin.saveSettings(); this.plugin.refreshOpenViews()}))
             .then((settingEl) => this.addResetButton(settingEl, 'searchDelay'))
+
+        new Setting(containerEl)
+            .setName('Search online URL')
+            .setDesc('URL to query when searching online')
+            .addText((text) => text
+                .setValue(this.plugin.settings.searchOnlineUrl)
+                .onChange((value) => {
+                    this.plugin.settings.searchOnlineUrl = value
+					this.plugin.saveSettings()
+                }))
+            .then((settingEl) => this.addResetButton(settingEl, 'searchOnlineUrl'))
 
         if(this.plugin.app.plugins.getPlugin('omnisearch')){
             new Setting(containerEl)

--- a/src/styles.css
+++ b/src/styles.css
@@ -80,6 +80,7 @@
     align-items: center;
     justify-content: space-evenly;
     flex-wrap: wrap;
+    gap: 2px;
 }
 
 .home-tab-searchbar.is-active{

--- a/src/ui/svelteComponents/homeTabFileSuggestion.svelte
+++ b/src/ui/svelteComponents/homeTabFileSuggestion.svelte
@@ -1,19 +1,26 @@
 <script lang="ts">
     import type Fuse from 'fuse.js'
-	import { FilePlus, FileQuestion, Forward, Folder } from "lucide-svelte";
+	import { FilePlus, FileQuestion, Forward, Folder, Search } from "lucide-svelte";
     import type { SearchFile } from "src/suggester/fuzzySearch";
 	import type { TextInputSuggester } from "src/suggester/suggester";
+	import type { HomeTabSettings } from "src/settings";
+	import { pluginSettingsStore } from 'src/store';
 	import Suggestion from './suggestion.svelte';
 
     export let index: number
     export let textInputSuggester: TextInputSuggester<SearchFile>
     export let selectedItemIndex: number
     export let suggestion: Fuse.FuseResult<SearchFile>
+    export let pluginSettings: HomeTabSettings
 
     export let nameToDisplay: string
     export let filePath: string | undefined = undefined
 
     let suggestionItem = suggestion.item
+
+    pluginSettingsStore.subscribe((settings) => {
+        pluginSettings = settings
+    })
 </script>
 
 <Suggestion {index} {textInputSuggester} {selectedItemIndex}
@@ -43,12 +50,19 @@
         <!-- Display if a file is not created -->
         {#if !suggestionItem.isCreated}
             <div class="home-tab-suggestion-tip">
-                {#if suggestionItem.isUnresolved}
-                    <FilePlus size={15} aria-label={'Not created yet, select to create'}/>
+                {#if pluginSettings.absentFileBehaviour === 'createFile'}
+                    {#if suggestionItem.isUnresolved}
+                        <FilePlus size={15} aria-label={'Not created yet, select to create'}/>
+                    {:else}
+                        <FileQuestion size={15} aria-label={'Not exists yet, select to create'}/>
+                        <div class="suggestion-hotkey">
+                            <span>Enter to create</span>
+                        </div>
+                    {/if}
                 {:else}
-                    <FileQuestion size={15} aria-label={'Non exists yet, select to create'}/>
+                    <Search size={15} aria-label={'Not exists, select to search online'}/>
                     <div class="suggestion-hotkey">
-                        <span>Enter to create</span>
+                        <span>Enter to search online</span>
                     </div>
                 {/if}
             </div>


### PR DESCRIPTION
## Description
Adds support for online search, works without Surfing but integrates seemingly with it. This should address and resolve #1.

I've seen some commits addressing this, but they didn't seem to be implemented yet. This should fix it in the meantime, and also adds functionality even without Surfing.

## Features

- Pressing <kbd>Alt</kbd>+<kbd>Enter</kbd> always performs an online search
- Pressing <kbd>Mod</kbd>+<kbd>Alt</kbd>+<kbd>Enter</kbd> does the same in a new tab
- Setting: search online instead of creating file when the input isn't an existing file
- Setting: change default search engine
- Changes the icon and text to indicate that an online search will be performed instead of creating a file

## Notes
I tried combining different settings to ensure everything works properly. I haven't worked with Svelte or Obsidian's API previously, so this may not follow best practices but I tried to achieve consistency with existing code.

Potential improvements include using a dropdown to select search engines instead of writing the URL, and showing search results in the current tab instead of opening a new one and closing the previous.