### PR TITLE
New feature: Search for Headings and Title 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,5 +27,7 @@ data.json
 .npmrc
 .esbuild.config.mjs
 version-bump.mjs
-tsconfig.json
+# tsconfig.json
 versions.json
+
+ref/

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ version-bump.mjs
 versions.json
 
 ref/
+rel/

--- a/dist/styles.css
+++ b/dist/styles.css
@@ -1,0 +1,101 @@
+.home-tab-suggestion-description, .home-tab-suggestion-filepath, .home-tab-suggestion-tip{
+    display: flex;
+    align-items: center;
+    justify-content: left;
+
+    color: var(--text-faint);
+}
+.home-tab-suggestion-description, .home-tab-suggestion-tip{
+    font-size: var(--font-ui-small)
+}
+.home-tab-suggestion-filepath{
+    font-size: var(--font-ui-smaller);
+    margin-left: var(--size-4-3);
+}
+.home-tab-suggestion-description svg, .home-tab-suggestion-filepath svg{
+    margin-right: 5px;
+}
+
+.home-tab-suggestion-container{
+    width: 50%;
+    min-width: 250px;
+    max-width: 700px;
+    margin: 0 auto;
+
+    background: var(--background-modifier-form-field);
+
+    border: var(--input-border-width) solid var(--background-modifier-border);
+    border-top-color: var(--background-secondary);
+    border-radius: 0 0 var(--input-radius) var(--input-radius);
+}
+
+.home-tab-searchbar.embedded+.home-tab-suggestion-container, .home-tab-suggestion-container.is-phone{
+    width: 90%;
+}
+
+
+.home-tab-suggestion-container .suggestion{
+    flex: 1;
+    overflow-x: hidden;
+}
+
+.home-tab-suggestion-title{
+    display: flex;
+    /* flex-wrap: wrap; */
+    word-break: break-word;
+}
+
+.home-tab-suggestion-title.is-unresolved{
+    opacity: 0.4;
+}
+
+.home-tab-suggestion-file-tag{
+    min-width: fit-content;
+}
+.suggestion.use-accent-color .is-selected .home-tab-suggestion-title.is-unresolved{
+    color: var(--text-on-accent);
+    opacity: 0.6;
+}
+
+.suggestion.use-accent-color .is-selected{
+    background-color: var(--interactive-accent);
+}
+.suggestion.use-accent-color .is-selected,
+.suggestion.use-accent-color .is-selected .home-tab-suggestion-filepath,
+.suggestion.use-accent-color .is-selected .home-tab-suggestion-description, 
+.suggestion.use-accent-color .is-selected .home-tab-suggestion-tip{
+    color: var(--text-on-accent);
+}
+
+.suggester-additional-info{
+    border-top: 1px solid var(--background-secondary);
+    font-size: var(--font-ui-smaller);
+    color: var(--text-muted);
+    padding: var(--size-4-2);
+    text-align: center;
+}
+
+.home-tab-hotkey-suggestions{
+    display: flex;
+    align-items: center;
+    justify-content: space-evenly;
+    flex-wrap: wrap;
+}
+
+.home-tab-searchbar.is-active{
+    border-bottom: none !important;
+    border-bottom-left-radius: 0 !important;
+    border-bottom-right-radius: 0 !important;
+}
+
+.wide-input-container{
+    width: 100%;
+}
+
+.setting-item-info.compressed{
+    width: 40%;
+}
+
+.setting-item-info.ultra-compressed{
+    width: 20%;
+}

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -41,7 +41,7 @@ esbuild.build({
 	logLevel: "info",
 	sourcemap: prod ? false : 'inline',
 	treeShaking: true,
-	outfile: prod ? 'main.js' : '../developmentVault/.obsidian/plugins/home-tab/main.js',
+	outfile: 'dist/main.js',
 	plugins: [
 		esbuildSvelte({
 		  compilerOptions: { css: true },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"main": "main.js",
 	"scripts": {
 		"dev": "node esbuild.config.mjs",
-		"build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
+		"build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production && node scripts/copy-styles.mjs",
 		"version": "node version-bump.mjs && git add manifest.json versions.json"
 	},
 	"keywords": [],

--- a/scripts/copy-styles.mjs
+++ b/scripts/copy-styles.mjs
@@ -1,0 +1,21 @@
+import { copyFile, mkdir } from 'fs/promises';
+import { dirname } from 'path';
+
+async function copyStyles() {
+    const sourceFile = 'src/styles.css';
+    const targetFile = 'dist/styles.css';
+
+    try {
+        // Ensure the dist directory exists
+        await mkdir(dirname(targetFile), { recursive: true });
+        
+        // Copy the styles.css file
+        await copyFile(sourceFile, targetFile);
+        console.log('Successfully copied styles.css to dist folder');
+    } catch (error) {
+        console.error('Error copying styles.css:', error);
+        process.exit(1);
+    }
+}
+
+copyStyles();

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -47,6 +47,8 @@ export interface HomeTabSettings extends ObjectKeys{
     showShortcuts: boolean
     markdownOnly: boolean
     unresolvedLinks: boolean
+    searchTitle: boolean
+    searchHeadings: boolean
     recentFilesStore: recentFileStore[]
     bookmarkedFileStore: bookmarkedFileStore[]
     searchDelay: number
@@ -80,6 +82,8 @@ export const DEFAULT_SETTINGS: HomeTabSettings = {
     showShortcuts: true,
     markdownOnly: false,
     unresolvedLinks: false,
+    searchTitle: false,
+    searchHeadings: false,
     recentFilesStore: [],
     bookmarkedFileStore: [],
     searchDelay: 0,
@@ -149,6 +153,20 @@ export class HomeTabSettingTab extends PluginSettingTab{
                 .addToggle(toggle => toggle
                     .setValue(this.plugin.settings.unresolvedLinks)
                     .onChange(value => {this.plugin.settings.unresolvedLinks = value; this.plugin.saveSettings(); this.plugin.refreshOpenViews()}))
+            
+            new Setting(containerEl)
+                .setName('Search file titles')
+                .setDesc('Enable this to search through file titles.')
+                .addToggle(toggle => toggle
+                    .setValue(this.plugin.settings.searchTitle)
+                    .onChange(value => {this.plugin.settings.searchTitle = value; this.plugin.saveSettings(); this.plugin.refreshOpenViews()}))
+            
+            new Setting(containerEl)
+                .setName('Search headings')
+                .setDesc('Enable this to search through document headings (# Title).')
+                .addToggle(toggle => toggle
+                    .setValue(this.plugin.settings.searchHeadings)
+                    .onChange(value => {this.plugin.settings.searchHeadings = value; this.plugin.saveSettings(); this.plugin.refreshOpenViews()}))
             
             new Setting(containerEl)
                 .setName('Show file path')

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -83,7 +83,7 @@ export const DEFAULT_SETTINGS: HomeTabSettings = {
     markdownOnly: false,
     unresolvedLinks: false,
     searchTitle: false,
-    searchHeadings: false,
+    searchHeadings: true,
     recentFilesStore: [],
     bookmarkedFileStore: [],
     searchDelay: 0,

--- a/src/suggester/fuzzySearch.ts
+++ b/src/suggester/fuzzySearch.ts
@@ -6,8 +6,8 @@ import type { SurfingItem } from "./surfingSuggester";
 
 export const DEFAULT_FUSE_OPTIONS: Fuse.IFuseOptions<any> = {
     includeScore : true,
-    // includeMatches : true,
-    // findAllMatches : true,
+    includeMatches : true,
+    findAllMatches : true,
     fieldNormWeight : 1.35,
     threshold : 0.2,
     distance: 125,
@@ -28,6 +28,8 @@ export interface SearchFile{
     basename: string
     path: string
     aliases?: string[]
+    title?: string
+    headings?: string[]
     isCreated: boolean
     isUnresolved?: boolean
     file?: TFile
@@ -105,6 +107,15 @@ export class FileFuzzySearch extends fuzzySearch<SearchFile>{
         const searchFile = searchResultElement.item
         // if(searchFile.fileType != 'markdown') return searchFile.name
         
+        // Check if the match is from headings
+        if (searchResultElement.matches?.some(match => match.key === 'headings')) {
+            const headingMatch = searchResultElement.matches?.find(match => match.key === 'headings')
+            if (headingMatch && headingMatch.value) {
+                // Return the actual heading text that matched
+                return headingMatch.value as string
+            }
+        }
+
         if (!searchFile.aliases) return searchFile.basename
 
         const searchArray: string[] = []
@@ -134,4 +145,3 @@ export class SurfingItemFuzzySearch extends fuzzySearch<SurfingItem>{
         super(surfingItems, searchOptions)
     }
 }
-

--- a/src/suggester/fuzzySearch.ts
+++ b/src/suggester/fuzzySearch.ts
@@ -109,10 +109,19 @@ export class FileFuzzySearch extends fuzzySearch<SearchFile>{
         
         // Check if the match is from headings
         if (searchResultElement.matches?.some(match => match.key === 'headings')) {
-            const headingMatch = searchResultElement.matches?.find(match => match.key === 'headings')
-            if (headingMatch && headingMatch.value) {
-                // Return the actual heading text that matched
-                return headingMatch.value as string
+            // Find all heading matches and sort by score
+            const headingMatches = searchResultElement.matches
+                .filter(match => match.key === 'headings')
+                .sort((a, b) => {
+                    const scoreA = a.indices[0][0] || 0
+                    const scoreB = b.indices[0][0] || 0
+                    return scoreA - scoreB
+                })
+
+            // Get the best heading match
+            const bestHeadingMatch = headingMatches[0]
+            if (bestHeadingMatch && bestHeadingMatch.value) {
+                return searchFile.basename
             }
         }
 

--- a/src/suggester/homeTabSuggester.ts
+++ b/src/suggester/homeTabSuggester.ts
@@ -197,19 +197,23 @@ export default class HomeTabFileSuggester extends TextInputSuggester<Fuse.FuseRe
 
         // Check if the match is from a heading
         if (this.plugin.settings.searchHeadings && suggestion.matches) {
+            // Find the first heading match
             const headingMatch = suggestion.matches.find(match => match.key === 'headings')
             if (headingMatch && typeof headingMatch.value === 'string') {
                 matchedHeading = headingMatch.value
                 // Keep the basename as nameToDisplay when it's a heading match
                 nameToDisplay = suggestion.item.basename
-            } else {
-                // Only use fuzzy search for non-heading matches
-                nameToDisplay = this.fuzzySearch.getBestMatch(suggestion, this.inputEl.value)
+                // If we have a heading match, we skip other matches like aliases
+                return {
+                    nameToDisplay: nameToDisplay,
+                    filePath: filePath,
+                    matchedHeading: matchedHeading
+                }
             }
-        } else {
-            // No heading search enabled, use normal fuzzy search
-            nameToDisplay = this.fuzzySearch.getBestMatch(suggestion, this.inputEl.value)
         }
+
+        // Only use fuzzy search for non-heading matches
+        nameToDisplay = this.fuzzySearch.getBestMatch(suggestion, this.inputEl.value)
         
         return {
             nameToDisplay: nameToDisplay,

--- a/src/suggester/omnisearchSuggester.ts
+++ b/src/suggester/omnisearchSuggester.ts
@@ -99,14 +99,23 @@ export default class OmnisearchSuggester extends TextInputSuggester<ResultNoteAp
     }
 
     
-    getDisplayElementProps(suggestion: ResultNoteApi): {basename: string, excerpt: string}{
-        const escapedWords = suggestion.foundWords.map(word => escapeStringForRegExp(word))
-        const regex = concatenateStringsToRegex(escapedWords, 'gi')
-        
-        let content = this.plugin.settings.showOmnisearchExcerpt ? this.highlightMatches(suggestion.excerpt, regex) : ''
-        let basename = this.highlightMatches(suggestion.basename, regex)
-        
-        return {basename: basename, excerpt: content}
+    getDisplayElementProps(suggestion: ResultNoteApi): {nameToDisplay: string, filePath?: string, excerpt?: string}{
+        const nameToDisplay = suggestion.basename
+        let filePath: string | undefined = undefined
+        let excerpt: string | undefined = undefined
+        if(this.plugin.settings.showPath){
+            filePath = suggestion.path
+        }
+        if(this.plugin.settings.showOmnisearchExcerpt){
+            const escapedWords = suggestion.foundWords.map(word => escapeStringForRegExp(word))
+            const regex = concatenateStringsToRegex(escapedWords, 'gi')
+            excerpt = this.highlightMatches(suggestion.excerpt, regex)
+        }
+        return {
+            nameToDisplay: nameToDisplay,
+            filePath: filePath,
+            excerpt: excerpt
+        }
     }
 
     getDisplayElementComponentType(): typeof OmnisearchSuggestion{
@@ -123,6 +132,6 @@ export default class OmnisearchSuggester extends TextInputSuggester<ResultNoteAp
     }
 
     private highlightMatches(content: string, regexMatches: RegExp): string{
-        return content.replaceAll(regexMatches, (value) => `<span class="suggestion-highlight omnisearch-highlight omnisearch-default-highlight">${value}</span>`)
+        return content.replace(regexMatches, (match: string) => `<span class="suggestion-highlight omnisearch-highlight omnisearch-default-highlight">${match}</span>`)
     }
 }

--- a/src/suggester/surfingSuggester.ts
+++ b/src/suggester/surfingSuggester.ts
@@ -1,5 +1,5 @@
 import type Fuse from 'fuse.js'
-import { Platform, Plugin_2, View, WorkspaceLeaf, type App } from 'obsidian'
+import { Platform, Plugin, View, WorkspaceLeaf, type App } from 'obsidian'
 import type HomeTab from '../main'
 import type HomeTabSearchBar from "src/homeTabSearchbar"
 import { TextInputSuggester } from './suggester'
@@ -8,7 +8,7 @@ import { get } from 'svelte/store'
 import SurfingSuggestion from 'src/ui/svelteComponents/surfingSuggestion.svelte'
 import { SurfingItemFuzzySearch } from './fuzzySearch'
 
-interface SurfingPlugin extends Plugin_2{
+interface SurfingPlugin extends Plugin{
     settings: SurfingSettings
 }
 interface SurfingSettings{
@@ -17,10 +17,12 @@ interface SurfingSettings{
 interface SurfingView extends View{
     navigate: (url: string, addToHistory?: boolean, updateWebView?: boolean) => void
 }
-interface WebBrowserViewState{
+interface WebBrowserViewState extends Record<string, unknown> {
 	url: string
 	active?: boolean
+    title?: string
 }
+
 interface SurfingJSONstoreObj{
     bookmarks: SurfingBookmark[]
     categories: SurfingCategory[]
@@ -147,14 +149,22 @@ export default class SurfingSuggester extends TextInputSuggester<Fuse.FuseResult
     }
 
     
-    getDisplayElementProps(suggestion: Fuse.FuseResult<SurfingItem>): {info: string}{
-        let info: string = ''
+    getDisplayElementProps(suggestion: Fuse.FuseResult<SurfingItem>): Record<string, unknown>{
+        let info = ''
+        let nameToDisplay = ''
+        let url = ''
 
         if(suggestion.item.type === 'newUrl'){
             info = `Search with ${this.surfingPlugin.settings.defaultSearchEngine}`
+            nameToDisplay = suggestion.item.name || ''
+            url = suggestion.item.url || ''
         }
 
-        return {info: info}
+        return {
+            info,
+            nameToDisplay,
+            url
+        }
     }
 
     getDisplayElementComponentType(): typeof SurfingSuggestion{

--- a/src/ui/svelteComponents/homeTabFileSuggestion.svelte
+++ b/src/ui/svelteComponents/homeTabFileSuggestion.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import type Fuse from 'fuse.js'
-	import { FilePlus, FileQuestion, Forward, Folder } from "lucide-svelte";
+	import { FilePlus, FileQuestion, Forward, Folder, Hash } from "lucide-svelte";
     import type { SearchFile } from "src/suggester/fuzzySearch";
 	import type { TextInputSuggester } from "src/suggester/suggester";
 	import Suggestion from './suggestion.svelte';
@@ -12,6 +12,7 @@
 
     export let nameToDisplay: string
     export let filePath: string | undefined = undefined
+    export let matchedHeading: string | undefined = undefined
 
     let suggestionItem = suggestion.item
 </script>
@@ -35,6 +36,13 @@
                 <div class="home-tab-suggestion-description">
                     <Forward size={15} aria-label={'Alias of'}/>
                     <span>{suggestionItem.basename}</span>
+                </div>
+            {/if}
+            <!-- If the match is from a heading -->
+            {#if matchedHeading}
+                <div class="home-tab-suggestion-description">
+                    <Hash size={15} aria-label={'Heading'}/>
+                    <span>{matchedHeading}</span>
                 </div>
             {/if}
         {/if}

--- a/src/utils/getFileTypeUtils.ts
+++ b/src/utils/getFileTypeUtils.ts
@@ -1,5 +1,10 @@
 import type { TFile } from "obsidian"
+import { App } from 'obsidian'
 import { getUnresolvedLinkBasename, getUnresolvedLinkPath } from "./getFilesUtils"
+
+declare global {
+    var app: App;
+}
 
 const fileTypeLookupTable: FileTypeLookupTable = {
     image : ['jpg', 'jpeg', 'png', 'svg', 'gif', 'bmp'],
@@ -81,6 +86,20 @@ export function isUnresolved(unresolvedFile: unresolvedFile): boolean{
     }
 
     return false
+}
+
+export function isUnresolvedLink(filename: string): boolean{
+    const parentFiles = Object.entries(app.metadataCache.unresolvedLinks)
+    let isUnresolved = false
+
+    parentFiles.forEach(([_, links]) => {
+        const unresolvedLinks = Object.keys(links)
+        if(unresolvedLinks.includes(filename)){
+            isUnresolved = true
+        }
+    })
+
+    return isUnresolved
 }
 
 export function isMarkdown(file: TFile): boolean{

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,32 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "inlineSourceMap": true,
+    "inlineSources": true,
+    "module": "ESNext",
+    "target": "ES6",
+    "allowJs": true,
+    "noImplicitAny": true,
+    "moduleResolution": "node",
+    "importHelpers": true,
+    "isolatedModules": true,
+    "strictNullChecks": true,
+    "lib": [
+      "DOM",
+      "ES5",
+      "ES6",
+      "ES7"
+    ],
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": [
+      "node",
+      "svelte"
+    ]
+  },
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.svelte"
+  ]
+}


### PR DESCRIPTION
I added 2 settings to support searching `title` and `headings` (with Windsurf's help):
![image](https://github.com/user-attachments/assets/5799aa18-09dc-4d3d-a486-ff0aa7a917ac)

And now we can search headings:
![image](https://github.com/user-attachments/assets/3deed148-bc9a-41fe-9187-fa9b6260358c)

![image](https://github.com/user-attachments/assets/d7c6f4a6-9dec-43d0-aa79-b494244699b5)
